### PR TITLE
fix ava setup not working.

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -1,9 +1,7 @@
 const { fileLoader, mergeTypes } = require('merge-graphql-schemas');
 const path = require('path');
-const issueType = require('./types/node.graphql');
+const typesDir = path.join(__dirname, 'types');
 
-const typesArray = [issueType];
-
-const typeDefs = mergeTypes(typesArray, { all: true });
+const typeDefs = mergeTypes(fileLoader(typesDir), { all: true });
 
 module.exports = typeDefs;


### PR DESCRIPTION
`require('./types/node.graphql')`.

Since `babel` does not (by default) know how to transpile `.graphql` files, this import was causing `ava`'s internal transpilation step to fail. By removing it, everything starts working again.

Also, it is worth pointing out that if GraphQL schemas will be loded using `merge-graphql-schemas`, there is no need to `require` (import) them. One should use `fileLoader` instead.